### PR TITLE
Enable code coverage reporting with Codecov

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,6 +43,12 @@ jobs:
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://CFBaptista.github.io/FlightPhysics.jl/stable/)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://CFBaptista.github.io/FlightPhysics.jl/dev/)
 [![Build Status](https://github.com/CFBaptista/FlightPhysics.jl/actions/workflows/CI.yml/badge.svg?branch=master)](https://github.com/CFBaptista/FlightPhysics.jl/actions/workflows/CI.yml?query=branch%3Amaster)
+[![Coverage](https://codecov.io/gh/CFBaptista/FlightTest.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/CFBaptista/FlightTest.jl)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 [![Aqua](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 


### PR DESCRIPTION
Configure the CI GitHub Action to collect code coverage and to report results to Codecov.